### PR TITLE
Added basic multilingual support

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -1,8 +1,21 @@
 <footer class="bg-near-black bottom-0 w-100 pa3" role="contentinfo">
   <div class="flex justify-between">
-  <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.BaseURL }}" >
-    &copy; {{ now.Format "2006" }} {{ .Site.Title }}
-  </a>
-  {{ partial "social-follow.html" . }}
+    <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.BaseURL | relLangURL }}" >
+      &copy; {{ now.Format "2006" }} {{ .Site.Title }}
+    </a>
+    <div class="flex-l">
+      <a class="f4 fw4 no-underline white-90 dn dib-ns pv2 ph3" href="{{ .Permalink }}">
+        {{ .Site.Params.languageName | default .Lang }}
+      </a>
+      {{ if .IsTranslated }}
+        {{ range .Translations }}
+        <a class="f4 fw4 hover-white no-underline white-40 dn dib-ns pv2 ph3" href="{{ .Permalink }}">
+          {{ .Site.Params.languageName | default .Lang }}
+        </a>
+        {{ end}}
+      {{ end }}
+
+      {{ partial "social-follow.html" . }}
+    </div>
   </div>
 </footer>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -4,10 +4,10 @@
       &copy; {{ now.Format "2006" }} {{ .Site.Title }}
     </a>
     <div class="flex-l">
+      {{ if .IsTranslated }}
       <a class="f4 fw4 no-underline white-90 dn dib-ns pv2 ph3" href="{{ .Permalink }}">
         {{ .Site.Params.languageName | default .Lang }}
       </a>
-      {{ if .IsTranslated }}
         {{ range .Translations }}
         <a class="f4 fw4 hover-white no-underline white-40 dn dib-ns pv2 ph3" href="{{ .Permalink }}">
           {{ .Site.Params.languageName | default .Lang }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -1,6 +1,6 @@
 <nav class="pv3 ph3 ph4-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
-    <a href="{{ .Site.BaseURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
+    <a href="{{ .Site.BaseURL | relLangURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
       {{ .Site.Title }}
     </a>
     <div class="flex-l items-center">


### PR DESCRIPTION
The [footer now lists all available translations](https://i.imgur.com/MV3rBAB.png). Uses `.Lang` if `.Site.Params.languageName` is not available. Languages do not appear if there are no translations.

I'm not a proper web dev so the CSS may need some tweaking. I just picked what seemed somewhat obvious.

Links to the home page now also attach the language code in the URL.