### PR TITLE
Don't duplicate site title in home page TITLE tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
-    <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Title }} | {{ . }}{{ end }}{{ end }}</title>
+    <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
     <meta name="HandheldFriendly" content="True">
     <meta name="MobileOptimized" content="320">
 


### PR DESCRIPTION
Let's say your `.Site.Title` is "My Website". The code grabs `.Site.Title`, and then then checks to see if there's a `.Title`. When you're on the homepage, `.Title` is equivalent to `.Site.Title`, so that the browser bar will read:

> My Website | My Website

If we qualify `.Title` by confining it to the `.Params` namespace, then the site title isn't duplicated:

```<title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>```

> My Website

But it still picks up `.Title` from posts and pages, where a content title exists in front matter:

> My Website | About Me