### PR TITLE
Fix asset paths when baseURL has sub-folder

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,7 +19,7 @@
 
     {{ $stylesheet := .Site.Data.webpack_assets.app }}
     {{ with $stylesheet.css }}
-      <link href="{{ absURL (printf "%s%s" "/dist/" .) }}" rel="stylesheet">
+      <link href="{{ relURL (printf "%s%s" "dist/" .) }}" rel="stylesheet">
     {{ end }}
 
     {{ range .Site.Params.custom_css }}

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -1,4 +1,4 @@
 {{ $script := .Site.Data.webpack_assets.app }}
 {{ with $script.js }}
-  <script src="{{ absURL (printf "%s%s" "/dist/" .) }}"></script>
+  <script src="{{ relURL (printf "%s%s" "dist/" .) }}"></script>
 {{ end }}


### PR DESCRIPTION
Hi @budparr,

https://themes.gohugo.io/theme/gohugo-theme-ananke/, a case where baseURL contains sub-folder, is not rendering correctly.  It appears that absURL behaves differently when the path is prefixed with a `/` slash.  The fix is to simply remove that leading slash.

The documentation at https://gohugo.io/functions/absurl/ does not seem to mention this fact explicitly.  Maybe we should fix the hugoDocs too.

See also #97

Thanks!