### PR TITLE
Add I18n and introduce ".Site.Params.Dateformat"

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,20 @@
+[Recent]
+other = "Letzte"
+
+[All]
+other = "Alle"
+
+[More]
+other = "Mehr"
+
+[Whatsinthis]
+other = "Was ist in diesem"
+
+[readmore]
+other = "mehr lesen"
+
+[page]
+other = "Seite"
+
+[Belowyouwillfindpagesthatutilizethetaxonomyterm]
+other = "Seiten zur Taxonomy „{{ .Title }}“"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,20 @@
+[Recent]
+other = "Recent"
+
+[All]
+other = "All"
+
+[More]
+other = "More"
+
+[Whatsinthis]
+other = "What’s in this"
+
+[readmore]
+other = "read more"
+
+[page]
+other = "page"
+
+[Belowyouwillfindpagesthatutilizethetaxonomyterm]
+other = "Below you will find pages that utilize the taxonomy term „{{ .Title }}“"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,7 +19,7 @@
       </h1>
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
       <time class="f6 mv4 dib tracked" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
-        {{- .Date.Format "January 2, 2006" -}}
+        {{- default "January 2, 2006" .Site.Params.Dateformat | .Date.Format -}}
       </time>
     </header>
 

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <article class="cf pa3 pa4-m pa4-l">
     <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img mid-gray">
-      <p>Below you will find pages that utilize the taxonomy term “{{ .Title }}”</p>
+      <p>{{ T "Belowyouwillfindpagesthatutilizethetaxonomyterm" . }}”</p>
     </div>
   </article>
   <div class="mw8 center">    

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
       {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
        {{ with .Site.GetPage "section" $section_name }}
           <h1 class="flex-none">
-            Recent {{ .Title }}
+            {{ T "Recent" }} {{ .Title }}
           </h1>
         {{ end }}
 
@@ -33,7 +33,7 @@
 
       {{ if ge $section_count (add $n_posts 1) }}
       <section class="w-100">
-        <h1 class="f3">More</h1>
+        <h1 class="f3">{{ T "More" }}</h1>
         {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
         {{ range (first 4 (after $n_posts $section))  }}
           <h2 class="f5 fw4 mb4 dib mr3">
@@ -45,7 +45,7 @@
 
         {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
         {{ with .Site.GetPage "section" $section_name }}
-          <a href="{{ .URL }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">All {{.Title }}</a>
+          <a href="{{ .URL }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{T "All" }} {{.Title }}</a>
         {{ end }}
         </section>
       {{ end }}

--- a/layouts/partials/menu-contextual.html
+++ b/layouts/partials/menu-contextual.html
@@ -5,7 +5,7 @@
 
 {{- if .Params.toc -}}
   <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
-    <p class="f5 b mb3">What's in this {{ humanize .Type }}</p>
+    <p class="f5 b mb3">{{ T "Whatsinthis" }} {{ humanize .Type }}</p>
       {{ .TableOfContents }}
   </div>
 {{- end -}}
@@ -21,13 +21,13 @@
   <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
     <p class="f5 b mb3">Related</p>
     <ul class="pa0 list">
-	   {{ range . }}
-	     <li  class="mb2">
-          <a href="{{ .RelPermalink }}">
-            {{- .Title -}}
-          </a>
-        </li>
-	    {{ end }}
+      {{ range . }}
+      <li  class="mb2">
+        <a href="{{ .RelPermalink }}">
+          {{- .Title -}}
+        </a>
+      </li>
+      {{ end }}
     </ul>
 </div>
 {{ end }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -8,7 +8,7 @@
         <ul class="pl0 mr3">
           {{ range .Site.Menus.main }}
           <li class="list f5 f4-ns fw4 dib pr3">
-            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ .Name }} page">
+            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ .Name }}-{{ T "page" }}">
               {{ .Name }}
             </a>
           </li>

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -20,7 +20,7 @@
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
           {{ .Summary }}
         </div>
-          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{$.Param "read_more_copy" | default "read more" }}</a>
+          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{$.Param "read_more_copy" | default (T "readmore")  }}</a>
         {{/* TODO: add author
         <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
       </div>


### PR DESCRIPTION
Translations are in i18n/*.toml.
If ".Site.Params.Dateformat" doesn’t exist, it falls back to the default.