### PR TITLE
Add div to wrap social icons

### DIFF
--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -3,6 +3,6 @@
   <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.BaseURL }}" >
     &copy; {{ now.Format "2006" }} {{ .Site.Title }}
   </a>
-  {{ partial "social-follow.html" . }}
+    <div>{{ partial "social-follow.html" . }}</div>
   </div>
 </footer>


### PR DESCRIPTION
This applies the flexbox directive `justify-between` to the nav items, not the icons themselves.

Fixes #127