### PR TITLE
Removed hardcoded theme sample hero image.

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,4 +1,4 @@
-{{ $featured_image := .Param "featured_image" | default "images/gohugo-default-sample-hero-image.jpg" }}
+{{ $featured_image := .Param "featured_image"}}
 {{ if $featured_image }}
   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
   {{ $featured_image := (trim $featured_image "/") | absURL }}


### PR DESCRIPTION
This will allow the user to "blank" out the hero default set in the config. The if statement for blank was unreachable.

No changed needed to example site as the featured image is correctly specified in the front matter.