### PR TITLE
Added reading time and word count in article

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,6 +28,17 @@
     <main class="nested-copy-line-height lh-copy serif f4 nested-links nested-img mid-gray pr4-l w-two-thirds-l">
         {{- .Content -}}
       {{- partial "tags.html" . -}}
+
+      <div class="mt6">
+        {{ with .PrevInSection }}
+          << <a href="{{ .Permalink }}">{{ .Title }}</a>
+        {{ end }}
+        {{ with .NextInSection }}
+          <a href="{{ .Permalink }}">{{ .Title }}</a> >>
+        {{ end }}
+      </div>
+      
+
       <div class="mt6">
         {{ template "_internal/disqus.html" . }}
       </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,6 +21,8 @@
       <time class="f6 mv4 dib tracked" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
         {{- .Date.Format "January 2, 2006" -}}
       </time>
+      <span class="f6 mv4 dib tracked"> - {{ .ReadingTime}} minutes read</span>
+      <span class="f6 mv4 dib tracked"> - {{ .WordCount}} words</span>
     </header>
 
     <main class="nested-copy-line-height lh-copy serif f4 nested-links nested-img mid-gray pr4-l w-two-thirds-l">


### PR DESCRIPTION
At the beginning of the article, below the title, next to the pusblished date, are added both an _indication of the reading time_ and of _number of words_ contained in the article. See this example:

![screenshot](https://user-images.githubusercontent.com/1682803/46904732-3794ca80-cee9-11e8-8f2b-814ce0254dec.png)

It's implemented using the built-in Hugo **.ReadingTime** and **.WordCount** page variables. 