### PR TITLE
Ensure description param is used.

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -9,7 +9,7 @@
         <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
-        {{ with .Params.description }}
+        {{ with .Param "description" }}
           <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
             {{ . }}
           </h2>


### PR DESCRIPTION
I'm a bit new to hugo and the theme, but I found to use the exampleSite config.toml's description parameter correctly, I had to update the site-header.html to use {{ with .Param "description" }} instead of {{ with .Param.description }}.  Sorry if this is redundant or wrong!