### PR TITLE
add i18n translation support

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,17 @@
+[more]
+other = "Mehr"
+
+[allTitle]
+other = "Alle {{.Title }}"
+
+[recentTitle]
+other = "Neuste {{.Title }}"
+
+[readMore]
+other = "weiterlesen"
+
+[whatsInThis]
+other = "Was ist in dieser {{ .Type }}"
+
+[related]
+other = "Ähnliches"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,17 @@
+[more]
+other = "More"
+
+[allTitle]
+other = "All {{.Title }}"
+
+[recentTitle]
+other = "Recent {{.Title }}"
+
+[readMore]
+other = "read more"
+
+[whatsInThis]
+other = "What's in this {{ .Type }}"
+
+[related]
+other = "Related"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
       {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
        {{ with .Site.GetPage "section" $section_name }}
           <h1 class="flex-none">
-            {{$.Param "recent_copy" | default "Recent" }} {{ .Title }}
+            {{ i18n "recentTitle" . }}
           </h1>
         {{ end }}
 
@@ -33,7 +33,7 @@
 
       {{ if ge $section_count (add $n_posts 1) }}
       <section class="w-100">
-        <h1 class="f3">More</h1>
+        <h1 class="f3">{{ i18n "more" }}</h1>
         {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
         {{ range (first 4 (after $n_posts $section))  }}
           <h2 class="f5 fw4 mb4 dib mr3">
@@ -45,7 +45,7 @@
 
         {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
         {{ with .Site.GetPage "section" $section_name }}
-          <a href="{{ .URL }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">All {{.Title }}</a>
+          <a href="{{ .URL }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
         {{ end }}
         </section>
       {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
       {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
        {{ with .Site.GetPage "section" $section_name }}
           <h1 class="flex-none">
-            {{ i18n "recentTitle" . }}
+            {{ $.Param "recent_copy" | default (i18n "recentTitle" .) }}
           </h1>
         {{ end }}
 

--- a/layouts/partials/menu-contextual.html
+++ b/layouts/partials/menu-contextual.html
@@ -5,7 +5,7 @@
 
 {{- if .Params.toc -}}
   <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
-    <p class="f5 b mb3">What's in this {{ humanize .Type }}</p>
+    <p class="f5 b mb3">{{ i18n "whatsInThis" humanize .Type }}</p>
       {{ .TableOfContents }}
   </div>
 {{- end -}}
@@ -19,7 +19,7 @@
 
 {{ with $related }}
   <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
-    <p class="f5 b mb3">Related</p>
+    <p class="f5 b mb3">{{ i18n "related" }}</p>
     <ul class="pa0 list">
 	   {{ range . }}
 	     <li  class="mb2">

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -20,7 +20,7 @@
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
           {{ .Summary }}
         </div>
-          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{$.Param "read_more_copy" | default "read more" }}</a>
+          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ i18n "readMore" }}</a>
         {{/* TODO: add author
         <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
       </div>

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -20,7 +20,7 @@
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
           {{ .Summary }}
         </div>
-          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ i18n "readMore" }}</a>
+          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
         {{/* TODO: add author
         <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
       </div>


### PR DESCRIPTION
With this Draft PR I want to get early feedback on my approach for tackling #108 and I would really appreciate some feedback from @budparr, @regisphilibert and anyone else involved.

I implemented a few strings that are easily visible but that should also include most of the strings. This theme is actually quiet and there isn't much text to translate in the first place I think.

I switched to this branch for my own blog and you can see the changes live at: https://blog.jan-steinke.de

So far I only have the translations for "de"(German) and "en"(English). The multi language support build into Hugo should default to "en" if I can trust [the documentation](https://gohugo.io/content-management/multilingual/#configure-languages), I haven't actually checked if this is true but it should make sure that anyone using this theme with single language should be fine as well.
> `defaultContentLanguage` sets the project’s default language. If not set, the default language will be `en`.

One thing I consciously removed is the support for `recent_copy` and `read_more_copy` as I understood that these are for multi language support and should be unnecessary if we build into i18n support.

Things need clarification before WIP is done:

- [x] removal of `..._copy` parameters
 - keep it for backwards compatibility (https://github.com/budparr/gohugo-theme-ananke/pull/156#issuecomment-465339954)
- [ ] which languages should be supported with the first implementation
- [ ] anything else?