### PR TITLE
Fix TOC header

### DIFF
--- a/layouts/partials/menu-contextual.html
+++ b/layouts/partials/menu-contextual.html
@@ -5,7 +5,7 @@
 
 {{- if .Params.toc -}}
   <div class="bg-light-gray pa3 nested-list-reset nested-copy-line-height nested-links">
-    <p class="f5 b mb3">{{ i18n "whatsInThis" humanize .Type }}</p>
+    <p class="f5 b mb3">{{ i18n "whatsInThis" . }}</p>
       {{ .TableOfContents }}
   </div>
 {{- end -}}


### PR DESCRIPTION
In English, the translation that is supposed to be shown on top of the table of contents looks like this:

```toml
[whatsInThis]
other = "What's in this {{.Type }}"
```

When it is invoked, I think that something is wrong in the calling code: `{{ i18n "whatsInThis" humanize .Type }}`.

This should be called `{{ i18n "whatsInThis" . }` instead because then the i18n can access the `.Type`; otherwise you get a `<no value>` output.