### PR TITLE
Added a 'read more' button to the summary without image.

### DIFF
--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -9,5 +9,6 @@
     <div class="nested-links f5 lh-copy nested-copy-line-height">
       {{ .Summary  }}
     </div>
+    <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
   </div>
 </div>


### PR DESCRIPTION
I noticed that on the [front page](https://gohugo-ananke-theme-demo.netlify.com/), in the list with recent artciles, the summaries have a 'read more'-button. But if you navigate to the ['articles' page](https://gohugo-ananke-theme-demo.netlify.com/post/), there are no 'read more'-buttons in the summaries.
I'm not sure this is a bug or a feature.
But anyway, this merge request will add the 'read more' buttons where they are missing.