### PR TITLE
localization for form-contact.html shortcode

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -15,3 +15,18 @@ other = "Was ist in dieser {{ .Type }}"
 
 [related]
 other = "Ähnliches"
+
+[yourName]
+other = "Dein Name"
+
+[emailAddress]
+other = "Email Adresse"
+
+[message]
+other = "Nachricht"
+
+[emailRequiredNote]
+other = "Eine Email Adresse wird benötigt."
+
+[send]
+other = "Senden"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -15,3 +15,18 @@ other = "What's in this {{ .Type }}"
 
 [related]
 other = "Related"
+
+[yourName]
+other = "Your Name"
+
+[emailAddress]
+other = "Email Address"
+
+[message]
+other = "Message"
+
+[emailRequiredNote]
+other = "An email address is required."
+
+[send]
+other = "Send"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -15,3 +15,18 @@ other = "Qué hay en este {{ .Type }}"
 
 [related]
 other = "Relacionado"
+
+[yourName]
+other = "Tu nombre"
+
+[emailAddress]
+other = "Dirección de correo electrónico"
+
+[message]
+other = "Mensaje"
+
+[emailRequiredNote]
+other = "Se requiere una dirección de correo electrónico."
+
+[send]
+other = "Enviar"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -15,3 +15,18 @@ other = "Ce qui est dans {{ .Type }}"
 
 [related]
 other = "Lié"
+
+[yourName]
+other = "Votre nom"
+
+[emailAddress]
+other = "Adresse e-mail"
+
+[message]
+other = "Message"
+
+[emailRequiredNote]
+other = "Une adresse e-mail est requise."
+
+[send]
+other = "Envoyer"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -15,3 +15,18 @@ other = "Inhoud van deze {{ .Type }}"
 
 [related]
 other = "Gerelateerd"
+
+[yourName]
+other = "Uw naam"
+
+[emailAddress]
+other = "E-mail adres"
+
+[message]
+other = "Boodschap"
+
+[emailRequiredNote]
+other = "Een e-mailadres is vereist."
+
+[send]
+other = "Stuur"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -15,3 +15,18 @@ other = "O que há neste {{ .Type }}"
 
 [related]
 other = "Relacionado"
+
+[yourName]
+other = "O teu nome"
+
+[emailAddress]
+other = "Endereço de e-mail"
+
+[message]
+other = "Mensagem"
+
+[emailRequiredNote]
+other = "É necessário um endereço de e-mail."
+
+[send]
+other = "Enviar"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -15,3 +15,18 @@ other = "Содержание {{ .Type }}"
 
 [related]
 other = "Схожие"
+
+[yourName]
+other = "Ваше имя"
+
+[emailAddress]
+other = "Адрес электронной почты"
+
+[message]
+other = "Сообщение"
+
+[emailRequiredNote]
+other = "Требуется адрес электронной почты."
+
+[send]
+other = "трансмиссия"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -15,3 +15,18 @@ other = "What's in this {{ .Type }}"
 
 [related]
 other = "相關內容"
+
+[yourName]
+other = "你的名字"
+
+[emailAddress]
+other = "电邮地址"
+
+[message]
+other = "信息"
+
+[emailRequiredNote]
+other = "需要电子邮件地址。"
+
+[send]
+other = "发送"

--- a/layouts/shortcodes/form-contact.html
+++ b/layouts/shortcodes/form-contact.html
@@ -3,18 +3,18 @@
 
 <form class="black-80 sans-serif" accept-charset="UTF-8" action="{{ .Get "action" }}" method="POST" role="form">
 
-    <label class="{{ $.Scratch.Get "labelClasses" }}"  for="name">Your Name</label>
+    <label class="{{ $.Scratch.Get "labelClasses" }}"  for="name">{{ i18n "yourName" }}</label>
     <input type="text" id="name" name="name" class="{{ $.Scratch.Get "inputClasses" }}"  required placeholder=" "  aria-labelledby="name"/>
 
-    <label class="{{ $.Scratch.Get "labelClasses" }}" for="email">Email Address</label>
+    <label class="{{ $.Scratch.Get "labelClasses" }}" for="email">{{ i18n "emailAddress" }}</label>
     <input type="email" id="email" name="email" class="{{ $.Scratch.Get "inputClasses" }}"  required placeholder=" "  aria-labelledby="email"/>
     <div class="requirements f6 gray glow i ph3 overflow-hidden">
-      An email address is required.
+      {{ i18n "emailRequiredNote" }}
     </div>
 
-    <label class="{{ $.Scratch.Get "labelClasses" }}" for="message">Message</label>
+    <label class="{{ $.Scratch.Get "labelClasses" }}" for="message">{{ i18n "message" }}</label>
     <textarea id="message" name="message" class="{{ $.Scratch.Get "inputClasses" }} h4" aria-labelledby="message"></textarea>
 
-    <input class="db w-100 mv2 white pa3 bn hover-shadow hover-bg-blck bg-animate bg-black" type="submit" value="Send" />
+    <input class="db w-100 mv2 white pa3 bn hover-shadow hover-bg-blck bg-animate bg-black" type="submit" value="{{ i18n "send" }}" />
 
 </form>


### PR DESCRIPTION
I translated the static text in the form-contact.html shortcode to all supported langages.

German is my mother tongue, the rest I translated with [DeepL](https://www.deepl.com/translator) (except for Chinese, there I had to use Google Translate).

This fixes #184