### PR TITLE
changed min_version from float to string in theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "A Base theme for building full featured Hugo sites"
 homepage = "https://github.com/budparr/gohugo-theme-ananke"
 tags = ["website", "starter", "responsive", "Disqus", "blog", "Tachyons", "Multilingual"]
 features = ["posts", "shortcodes", "related content", "comments"]
-min_version = 0.30.2
+min_version = "0.30.2"
 
 [author]
   name = "Bud Parr"


### PR DESCRIPTION
When following this step:
https://gohugo.io/getting-started/quick-start/#step-4-add-some-content

The `hugo new posts/my-first-post.md` command failed with the following error:

```
PS C:\Hugo\Sites\quickstart> hugo new posts/my-first-post.md
Error: failed to read module config for "ananke" in "C:\\Hugo\\Sites\\quickstart\\themes\\ananke\\theme.toml": unmarshal failed: Near line 11 (last key parsed 'min_version'): Invalid float value: "0.30.2"
```