### PR TITLE
fix toml format

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "A Base theme for building full featured Hugo sites"
 homepage = "https://github.com/budparr/gohugo-theme-ananke"
 tags = ["website", "starter", "responsive", "Disqus", "blog", "Tachyons", "Multilingual"]
 features = ["posts", "shortcodes", "related content", "comments"]
-min_version = 0.30.2
+min_version = "0.30.2"
 
 [author]
   name = "Bud Parr"


### PR DESCRIPTION
without `Hugo` complained with:
```
Error: failed to read module config for "ananke" in "[...]/quickstart/themes/ananke/theme.toml": unmarshal failed: Near line 11 (last key parsed 'min_version'): Invalid float value: "0.30.2"
```