### PR TITLE
Use environment introduced in Hugo 0.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also includes examples of Hugo Features or Functions:
 - Hugo built-in menu
 - i18n
 - `with`
-- `HUGO_ENV`
+- `HUGO_ENVIRONMENT`
 - `first`
 - `after`
 - `sort`
@@ -149,10 +149,10 @@ Now enter [`localhost:1313`](http://localhost:1313/) in the address bar of your 
 
 ## Production
 
-To run in production (e.g. to have Google Analytics show up), run `HUGO_ENV=production` before your build command. For example:
+To run in production (e.g. to have Google Analytics show up), either run just `hugo` (without the `server` command), add `HUGO_ENVIRONMENT=production` before your build command or use `hugo server --environment=production`. For example:
 
 ```
-HUGO_ENV=production hugo
+hugo
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Also includes examples of Hugo Features or Functions:
 - Hugo built-in menu
 - i18n
 - `with`
-- `HUGO_ENVIRONMENT`
+- `HUGO_ENV`
 - `first`
 - `after`
 - `sort`
@@ -149,10 +149,10 @@ Now enter [`localhost:1313`](http://localhost:1313/) in the address bar of your 
 
 ## Production
 
-To run in production (e.g. to have Google Analytics show up), either run just `hugo` (without the `server` command), add `HUGO_ENVIRONMENT=production` before your build command or use `hugo server --environment=production`. For example:
+To run in production (e.g. to have Google Analytics show up), run `HUGO_ENV=production` before your build command. For example:
 
 ```
-hugo
+HUGO_ENV=production hugo
 ```
 
 ## Contributing

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     {{ .Hugo.Generator }}
     {{/* NOTE: For Production make sure you add `HUGO_ENVIRONMENT="production"` before your build command */}}
-    {{ if eq hugo.Environment "production" }}
+    {{ if eq (getenv "HUGO_ENV") "production" | or (eq hugo.Environment "production") }}
       <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
     {{ else }}
       <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,9 +6,9 @@
     {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
     <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1">
-    {{ hugo.Generator }}
-    {{/* NOTE: For Production make sure you add `HUGO_ENV="production"` before your build command */}}
-    {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+    {{ .Hugo.Generator }}
+    {{/* NOTE: For Production make sure you add `HUGO_ENVIRONMENT="production"` before your build command */}}
+    {{ if eq hugo.Environment "production" }}
       <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
     {{ else }}
       <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
@@ -39,12 +39,12 @@
     {{- template "_internal/schema.html" . -}}
     {{- template "_internal/twitter_cards.html" . -}}
 
-    {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+    {{ if eq hugo.Environment "production" }}
       {{ template "_internal/google_analytics_async.html" . }}
     {{ end }}
   </head>
 
-  <body class="ma0 {{ $.Param "body_classes"  | default "avenir bg-near-white"}}{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
+  <body class="ma0 {{ $.Param "body_classes"  | default "avenir bg-near-white"}}{{ with hugo.Environment }} {{ . }}{{ end }}">
 
     {{ block "header" . }}{{ partial "site-header.html" .}}{{ end }}
     <main class="pb7" role="main">

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
-# robotstxt.org - if ENV production variable is false robots will be disallowed.
-{{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+# robotstxt.org - if environment is not production robots will be disallowed.
+{{ if eq hugo.Environment "production" }}
   Disallow:
 {{ else }}
   Disallow: /

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 # robotstxt.org - if environment is not production robots will be disallowed.
-{{ if eq hugo.Environment "production" }}
+{{ if eq (getenv "HUGO_ENV") "production" | or (eq hugo.Environment "production") }}
   Disallow:
 {{ else }}
   Disallow: /


### PR DESCRIPTION
The Ananke theme got environment support before Hugo did and when Hugo
added it in version 0.53 it was in a slightly different way. Running
"hugo server" will set the environment to "development" and running just
"hugo" will set it to "production". It can be overridden by OS
environment variable "HUGO_ENVIRONMENT" (note, not "HUGO_ENV") or by
using the --environment option.

Use "hugo.Environment" to detect environment instead and update the
README.

Resolves #201.