### PR TITLE
Fixes #212

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,10 +28,12 @@
     {{ end }}
 
     {{ if .OutputFormats.Get "RSS" }}
-      <link href="{{ .OutputFormats.Get "RSS" }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-      <link href="{{ .OutputFormats.Get "RSS" }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ with .OutputFormats.Get "RSS" }}
+      <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+      <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
+      {{ end }}
     {{ end }}
-
+    
     {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/spf13/hugo/blob/master/tpl/tplimpl/template_embedded.go#L158 */}}
     {{- template "_internal/opengraph.html" . -}}
     {{- template "_internal/schema.html" . -}}


### PR DESCRIPTION
Follows the template in the Hugo documentation [here](https://gohugo.io/templates/output-formats/). 

The issue is that calling `.OutputFormats.Get` returns a JSON blob. This was rendered as an `href` attribute, thus causing the error.