### PR TITLE
Replace {{ .URL }} with {{ .Permalink }}

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
         {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
         {{ range (first 4 (after $n_posts $section))  }}
           <h2 class="f5 fw4 mb4 dib mr3">
-            <a href="{{ .URL }}" class="link black dim">
+            <a href="{{ .Permalink }}" class="link black dim">
               {{ .Title }}
             </a>
           </h2>
@@ -45,7 +45,7 @@
 
         {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
         {{ with .Site.GetPage "section" $section_name }}
-          <a href="{{ .URL }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
+          <a href="{{ .Permalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
         {{ end }}
         </section>
       {{ end }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -9,7 +9,7 @@
         <ul class="pl0 mr3">
           {{ range .Site.Menus.main }}
           <li class="list f5 f4-ns fw4 dib pr3">
-            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ .Name }} page">
+            <a class="hover-white no-underline white-90" href="{{ .Permalink }}" title="{{ .Name }} page">
               {{ .Name }}
             </a>
           </li>

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -6,21 +6,21 @@
           {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
         {{ $featured_image := (trim $featured_image "/") | absURL }}
         <div class="pr3-ns mb4 mb0-ns w-100 w-40-ns">
-          <a href="{{.URL}}" class="db grow">
+          <a href="{{.Permalink}}" class="db grow">
             <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}">
           </a>
         </div>
       {{ end }}
       <div class="blah w-100{{ if .Params.featured_image }} w-60-ns pl3-ns{{ end }}">
         <h1 class="f3 fw1 athelas mt0 lh-title">
-          <a href="{{.URL}}" class="color-inherit dim link">
+          <a href="{{.Permalink}}" class="color-inherit dim link">
             {{ .Title }}
             </a>
         </h1>
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
           {{ .Summary }}
         </div>
-          <a href="{{.URL}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+          <a href="{{.Permalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
         {{/* TODO: add author
         <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
       </div>

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -2,7 +2,7 @@
   <div class="bg-white mb3 pa4 gray overflow-hidden">
     <span class="f6 db">{{ humanize .Section }}</span>
     <h1 class="f3 near-black">
-      <a href="{{ .URL }}" class="link black dim">
+      <a href="{{ .Permalink }}" class="link black dim">
         {{ .Title }}
       </a>
     </h1>

--- a/layouts/post/summary-with-image.html
+++ b/layouts/post/summary-with-image.html
@@ -1,5 +1,5 @@
 <article class="bb b--black-10">
-  <a class="db pv4 ph3 ph0-l no-underline dark-gray dim" href="{{ .URL }}">
+  <a class="db pv4 ph3 ph0-l no-underline dark-gray dim" href="{{ .Permalink }}">
     <div class="flex flex-column flex-row-ns">
       {{ if .Params.featured_image }}
         <div class="pr3-ns mb4 mb0-ns w-100 w-40-ns">

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -5,7 +5,7 @@
       </div>
     {{ end }}
     <h1 class="f3 near-black">
-      <a href="{{ .URL }}" class="link black dim">
+      <a href="{{ .Permalink }}" class="link black dim">
         {{ .Title }}
       </a>
     </h1>


### PR DESCRIPTION
Using the `{{ .URL }}` token results in a warning:

    WARN 2019/10/13 15:12:12 Page's .URL is deprecated and will be removed in a
    future release. Use .Permalink or .RelPermalink. If what you want is the
    front matter URL value, use .Params.url.

### Steps to reproduce

Follow along with the Quick Start guide at
https://gohugo.io/getting-started/quick-start/

Running `hugo server -D` emits a warning that `.URL` is deprecated.