### PR TITLE
Fix compile error caused by MenuEntry not having a .Permalink

### DIFF
--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -9,7 +9,7 @@
         <ul class="pl0 mr3">
           {{ range .Site.Menus.main }}
           <li class="list f5 f4-ns fw4 dib pr3">
-            <a class="hover-white no-underline white-90" href="{{ .Permalink }}" title="{{ .Name }} page">
+            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ .Name }} page">
               {{ .Name }}
             </a>
           </li>


### PR DESCRIPTION
Fixes issue in recent change that changes {{.URL}} to {{.Permalink}},
but shouldn't have been done for navigation.MenuItems.

To reproduce: `hugo server -D` will spew errors, so long as you have a menu defined in config.toml

After updating to this fix, hugo resumes building normally.