### PR TITLE
Fix to take care of multiple author list

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,7 +20,13 @@
       </h1>
       {{ with .Params.author }}
       <p class="tracked">
-         By <strong>{{ . | markdownify }}</strong>
+          By <strong>
+          {{ if reflect.IsSlice . }}
+              {{ delimit . ", " | markdownify }}
+          {{else}}
+              {{ . | markdownify }}
+          {{ end }}
+          </strong>
       </p>
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}


### PR DESCRIPTION
In case the author parameter is a []string, which is the default for ox-hugo
output.