### PR TITLE
Fix word count heading typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For example, if your css files are `static/css/custom.css` and `static/css/custo
       custom_css = ["css/custom.css","css/custom2.css"]
 ```
 
-### Show Reading Time and Word Contributing
+### Show Reading Time and Word Count
 
 If you add a key of `show_reading_time` true to either the Config Params, a page or section's front matter, articles will show the reading time and word count.
 


### PR DESCRIPTION
The heading says "Word Contributing"  where it should say "Word Count"