### PR TITLE
Fix Slack icon size

### DIFF
--- a/layouts/partials/svg/slack.svg
+++ b/layouts/partials/svg/slack.svg
@@ -1,4 +1,4 @@
-<svg {{ with .size }} height="{{ . }}" {{ end }} style="enable-background:new 0 0 270 270;" version="1.1" viewBox="0 0 270 270" width="{{ .size }}" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+<svg {{ with .size }} height="{{ . }}" {{ end }} style="enable-background:new 65 65 150 135;" version="1.1" viewBox="65 65 150 135" width="{{ .size }}" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
 <style type="text/css">
 	.st0{fill:#BABABA;}
 </style>

--- a/src/css/_social-icons.css
+++ b/src/css/_social-icons.css
@@ -48,6 +48,6 @@
 }
 
 .slack:hover {
-  fill: #3088d4;
+  fill: #E01E5A;
 }
 


### PR DESCRIPTION
The hover color is still not working, but now the icon size matches the others:

![](https://zappy.zapier.com/BCCB72F4-E34E-451C-97F1-763834AC6AE5.png)