### PR TITLE
Add the option to use a logo for the top left site title

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ For example, if your css files are `static/css/custom.css` and `static/css/custo
 If you add a key of `show_reading_time` true to either the Config Params, a page or section's front matter, articles will show the reading time and word count.
 
 
+### Logo
+
+You can replace the title of your site in the top left corner of each page with your own logo. To do that put your own logo into the `static` directory of your website, and add the `logo` parameter to the site params in your config file. For example:
+
+```
+[params]
+  logo = "img/logo.svg"
+```
+
+
 ### Nearly finished
 
 In order to see your site in action, run Hugo's built-in local server.

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -1,7 +1,11 @@
 <nav class="pv3 ph3 ph4-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
     <a href="{{ .Site.BaseURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
+    {{ if .Site.Params.Logo }}
+      <img src="{{ .Site.Params.Logo | relURL }}" alt="{{ .Site.Title }}" />
+    {{ else }}
       {{ .Site.Title }}
+    {{ end }}
     </a>
     <div class="flex-l items-center">
       {{ partial "i18nlist.html" . }}


### PR DESCRIPTION
This fixes issue #81, but it does so slightly differently. It replaces the site title with a logo, in the navigation section, if Site.Params.Logo is set. If not it just continues to print the title, as it has up 'til now. Rather than Lithium's approach of having dimensions set under the logo parameter (see https://github.com/jrutheiser/hugo-lithium-theme/blob/master/exampleSite/config.toml) I just went for simplicity, figuring people would be happy to just set the dimensions in the image, or CSS, themselves.

This is my first hugo theme adjustment, so please check it over for any stupid mistakes!