### PR TITLE
Use relative URL for favicon

### DIFF
--- a/layouts/partials/site-favicon.html
+++ b/layouts/partials/site-favicon.html
@@ -1,3 +1,3 @@
 {{ if .Site.Params.favicon }}
-<link rel="shortcut icon" href="/{{ .Site.Params.favicon }}" type="image/x-icon" />
+<link rel="shortcut icon" href="{{ relURL ($.Site.Params.favicon) }}" type="image/x-icon" />
 {{ end }}


### PR DESCRIPTION
This fixes sites which have the baseURL in a subdirectory.