### PR TITLE
Fix relURL for custom_css

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
     {{ end }}
 
     {{ range .Site.Params.custom_css }}
-      <link rel="stylesheet" href="{{ relURL ($.Site.BaseURL) }}{{ . }}">
+      <link rel="stylesheet" href="{{ relURL (.) }}">
     {{ end }}
 
     {{ block "favicon" . }}


### PR DESCRIPTION
The way relURL was used meant that one needed to preface the custom_css
entries with a slash, or the href would be incorrectly set to
subdircss/mycss.css rather than subdir/css/mycss.css, in the case of
a baseURL in a subdir.