### PR TITLE
improved italian translation ([recentTitle] field)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ To run in production (e.g. to have Google Analytics show up), run `HUGO_ENV=prod
 HUGO_ENV=production hugo
 ```
 
+Note: The above command will not work on Windows. If you are running a Windows OS, use the below command:
+
+```
+hugo --environment production
+```
+
 ## Contributing
 
 If you find a bug or have an idea for a feature, feel free to use the [issue tracker](https://github.com/budparr/gohugo-theme-ananke/issues) to let me know.

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -5,7 +5,7 @@ other = "Altro"
 other = "Tutti {{.Title }}"
 
 [recentTitle]
-other = "Recenti {{.Title }}"
+other = "Articoli recenti"
 
 [readMore]
 other = "leggi di più"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
-    <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
+    <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     {{ hugo.Generator }}
     {{/* NOTE: For Production make sure you add `HUGO_ENV="production"` before your build command */}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,11 @@
       <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
     {{ end }}
 
+    {{if (.Params.mermaid)}}
+      <!-- MermaidJS support -->
+      <script async src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>
+    {{end}}
+
     {{ $stylesheet := .Site.Data.webpack_assets.app }}
     {{ with $stylesheet.css }}
       <link href="{{ relURL (printf "%s%s" "dist/" .) }}" rel="stylesheet">

--- a/layouts/partials/social-share.html
+++ b/layouts/partials/social-share.html
@@ -1,5 +1,5 @@
 {{ $title := .Title }}
-{{ $url := printf "%s" .URL | absLangURL }}
+{{ $url := printf "%s" .Permalink | absLangURL }}
 {{ $icon_size := "32px" }}
 
 {{ if not .Params.disable_share }}

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,0 +1,3 @@
+<div class="mermaid">
+  {{.Inner}}
+</div>


### PR DESCRIPTION
I started to use your theme for my personal renewed site, and I found a unsatisfactory translation for the `recentTitle` item in the translation file for the italian language.
With the current translation the italian resulting string is "Recenti posts" that does not sound right at all. A better translation is "Post recenti" but please note that Post should be used in singular (in italian, foreign terms are always used singular). I do not know if it is possibile to use `{{.Title }}` in some way to have it in singular form, so for the moment I decided to use another better (in my opinion) translation using the italian word "Articoli" instead of "Posts".
I am not sure but probably the same consideration apply to other translation.