### PR TITLE
Use | relLangURL for the base url in the site-navigation

### DIFF
--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -1,6 +1,6 @@
 <nav class="pv3 ph3 ph4-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
-    <a href="{{ .Site.BaseURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
+    <a href="{{ .Site.BaseURL | relLangURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
       {{ .Site.Title }}
     </a>
     <div class="flex-l items-center">

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -1,6 +1,6 @@
 <nav class="pv3 ph3 ph4-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
-    <a href="{{ .Site.BaseURL | relLangURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
+    <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 hover-white no-underline white-90 dib">
       {{ .Site.Title }}
     </a>
     <div class="flex-l items-center">


### PR DESCRIPTION
This way, when you click on the header it maintains you in the same language you previously selected.

