### PR TITLE
Add head partial

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,6 +42,7 @@
     {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
       {{ template "_internal/google_analytics_async.html" . }}
     {{ end }}
+	{{ block "head" . }}{{ partialCached "site-head.html" . }}{{ end }}
   </head>
 
   <body class="ma0 {{ $.Param "body_classes"  | default "avenir bg-near-white"}}{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">


### PR DESCRIPTION
Just added head partial to the template.
Some scripts need to be at the head, for example, Google AdSense, etc.
My workaround is to paste the script into the baseof.html
Instead of pasting directly to baseof.html, I recommend to just create a partial at the head to paste the scripts, etc. that needs to be at the head.