### PR TITLE
Fix rendering breakage introduced in #665

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -45,7 +45,7 @@
           {{ end }}
 
           {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
-          {{ with .Site.GetPage "section" $section_name }}
+          {{ with $.Site.GetPage "section" $section_name }}
             <a href="{{ .RelPermalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
           {{ end }}
           </section>


### PR DESCRIPTION
A bare bones setup of two pages and two posts gets broken because of a template change missed in #665

Fatal error message in readable form:
```
ERROR render:
failed to render pages:
render of "home" failed: "themes/ananke/layouts/index.html:48:23":
execute of template failed:
template:
index.html:48:23:
executing "main" at <.Site.GetPage>: can't evaluate field Site in type string
```

Steps to reproduce:

```shell
hugo new site quickstart
cd quickstart
git init
git submodule add https://github.com/theNewDynamic/gohugo-theme-ananke.git themes/ananke
echo "theme = 'ananke'" >> hugo.toml
echo -e "+++\ntitle='Home'\n+++\n\nMain page" > content/_index.md
echo Foo. > content/page1.md
echo Bar. > content/page2.md
mkdir -p content/post
echo "First post." > content/post/post1.md
echo "Second post." > content/post/post2.md
hugo server
```

Output:
```
Watching for changes in quickstart/{archetypes,assets,content,data,i18n,layouts,static,themes}
Watching for config changes in quickstart/hugo.toml, quickstart/themes/ananke/config.yaml
Start building sites …
hugo v0.125.3-474c4c02212cf97712c6fbf4159c68822ea6e078+extended darwin/amd64 BuildDate=2024-04-22T17:18:35Z VendorInfo=brew

Built in 67 ms
Error: error building site: render: failed to render pages: render of "home" failed: ".../quickstart/themes/ananke/layouts/index.html:48:23": execute of template failed: template: index.html:48:23: executing "main" at <.Site.GetPage>: can't evaluate field Site in type string
```