### PR TITLE
feat: add dynamic identifiers to body and article classes per page

### DIFF
--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -56,9 +56,22 @@
 	{{ block "head" . }}{{ partials.Include "head-additions.html" . }}{{ end }}
   </head>
 
-  {{- $environment := hugo.Environment | compare.Default "production" -}}
-  <body class="ma0 {{ $.Param "body_classes"  | compare.Default "avenir bg-near-white"}} {{ $environment }}">
+  {{- $environment := hugo.Environment | default "production" -}}
 
+  {{/* Generate dynamic classes for the body tag */}}
+  {{- $body_classes := slice "ma0" ($.Param "body_classes" | default "avenir bg-near-white") $environment -}}
+  {{- $body_classes = $body_classes | append (printf "is-%s" .Kind) -}}
+
+  {{- if .IsPage -}}
+    {{- $body_classes = $body_classes | append "is-page" -}}
+    {{- with .File -}}
+      {{- $body_classes = $body_classes | append (printf "page-%s" .ContentBaseName) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if .IsSection -}}{{- $body_classes = $body_classes | append "is-section" -}}{{- end -}}
+
+  <body class="{{ delimit $body_classes " " }}">
     {{ block "header" . }}{{ partials.Include "site-header.html" .}}{{ end }}
     <main class="pb7" role="main">
       {{ block "main" . }}{{ end }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,7 +1,13 @@
 {{ define "header" }}{{ partials.Include "page-header.html" . }}{{ end }}
 {{ define "main" }}
   <div class="flex-l mt2 mw8 center">
-    <article class="center cf pv5 ph3 ph4-ns mw7">
+    {{/* Calculate a unique class for this page */}}
+    {{- $post_class := "" -}}
+    {{- with .File -}}
+      {{- $post_class = printf "page-%s" .ContentBaseName -}}
+    {{- end -}}
+
+    <article class="{{ $post_class }} center cf pv5 ph3 ph4-ns mw7">
       <header>
         <h1 class="f1">
           {{ .Title }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -8,7 +8,14 @@
   {{- $needs_aside := or .Params.toc $related_content -}}
   {{ $page := .}}
   {{ $section := .Site.GetPage "section" .Section }}
-  <article class="flex-l {{ if $needs_aside }}mw8{{ else }}mw7{{ end }} center ph3 flex-wrap justify-between">
+
+  {{/* Calculate a unique class for this post */}}
+  {{- $post_class := "" -}}
+  {{- with .File -}}
+    {{- $post_class = printf "page-%s" .ContentBaseName -}}
+  {{- end -}}
+
+  <article class="{{ $post_class }} flex-l {{ if $needs_aside }}mw8{{ else }}mw7{{ end }} center ph3 flex-wrap justify-between">
     <header class="mt4 w-100">
       <aside class="instapaper_ignoref b helvetica tracked ttu">
           {{/*


### PR DESCRIPTION
This PR adds identifiers for the current post and page types to the body and article tags as requested in #815.

It allows users to style specific pages based on their content slug or page type (e.g., `is-page`, `is-section`, `page-about`).

Closes #815