### PR TITLE
update deprecated pagination config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,7 +6,7 @@ resourceDir = "../resources"
 
 DefaultContentLanguage = "en"
 SectionPagesMenu = "main"
-Paginate = 3                  # this is set low for demonstrating with dummy content. Set to a higher number
+pagination.pagerSize = 3                  # this is set low for demonstrating with dummy content. Set to a higher number
 googleAnalytics = ""
 enableRobotsTXT = true
 


### PR DESCRIPTION
to prevent the error message:

ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and subsequently removed. Use pagination.pagerSize instead.

As this is such a trivial change in a sample file, I didn't file an issue first, but just edited/PR'ed this file. If this is not ok and you need an issue: Please let me know.