### PR TITLE
docs: add notice about ananke move to org in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ananke is a flexible, production-ready starter theme for [Hugo](https://gohugo.i
 ![Ananke screenshot](images/screenshot.png)
 
 * Demo: [ananke-theme.netlify.app](https://ananke-theme.netlify.app/)
-* Documentation: [docs directory](https://github.com/theNewDynamic/gohugo-theme-ananke/tree/main/docs)
+* Documentation: [docs directory](https://github.com/gohugo-ananke/theme/tree/main/docs)
 * Changelog: [CHANGELOG.md](CHANGELOG.md)
 
 > [!IMPORTANT]
@@ -59,6 +59,6 @@ After installation, use these guides to configure your site:
 
 ## Support and Contributions
 
-* Bug reports: [GitHub Issues](https://github.com/theNewDynamic/gohugo-theme-ananke/issues)
-* Questions and feature ideas: [GitHub Discussions](https://github.com/theNewDynamic/gohugo-theme-ananke/discussions)
+* Bug reports: [GitHub Issues](https://github.com/gohugo-ananke/theme/issues)
+* Questions and feature ideas: [GitHub Discussions](https://github.com/gohugo-ananke/theme/discussions)
 * Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ Ananke is a flexible, production-ready starter theme for [Hugo](https://gohugo.i
 * Documentation: [docs directory](https://github.com/theNewDynamic/gohugo-theme-ananke/tree/main/docs)
 * Changelog: [CHANGELOG.md](CHANGELOG.md)
 
+> [!IMPORTANT]
+>
+> Ananke moved to its own organisation on April 18, 2026. Please update your references from `github.com/theNewDynamic/gohugo-theme-ananke` to `github.com/gohugo-ananke/theme`. Bear with us as we update all documentation and links to reflect this change. Until then, both URLs will continue to work as links as well as in the `git` operations for cloning and submodules.
+>
+> The following steps should suffice to update your references if you have not changed the setup:
+>
+> **For Hugo Modules:** search and replace all instances of `theNewDynamic/gohugo-theme-ananke` with `gohugo-ananke/theme` in your site's configuration and run `hugo mod tidy` to update the module dependencies.
+>
+> **For Git Submodules:** To change the remote URL for your existing submodule, run:
+>
+> ```bash
+> cd path/to/your/repo/themes/ananke # <-- adjust path as needed, keep the 'themes/ananke' part
+> git remote set-url origin https://github.com/gohugo-ananke/theme.git
+> ```
+>
+> Then find `.gitmodules` in the root of your repository and replace all instances of `theNewDynamic/gohugo-theme-ananke` with `gohugo-ananke/theme` in that file as well.
+> Finally, run `git submodule sync` to update the submodule configuration.
+>
+> **Issues?** Get in touch via [GitHub Discussions](https://github.com/gohugo-ananke/theme/discussions).
+
 ## Features
 
 * Responsive layouts and accessible markup

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ananke is a flexible, production-ready starter theme for [Hugo](https://gohugo.i
 >
 > The following steps should suffice to update your references if you have not changed the setup:
 >
-> **For Hugo Modules:** search and replace all instances of `theNewDynamic/gohugo-theme-ananke` with `gohugo-ananke/theme` in your site's configuration and run `hugo mod tidy` to update the module dependencies.
+> **For Hugo Modules:** search and replace all instances of `github.com/theNewDynamic/gohugo-theme-ananke/v2` with `github.com/gohugo-ananke/theme/v2` in your site's configuration and run `hugo mod tidy` to update the module dependencies.
 >
 > **For Git Submodules:** To change the remote URL for your existing submodule, run:
 >

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "Ananke: A theme for Hugo Sites",
 	"version": "2.13.0-prerelease.1",
 	"license": "MIT",
-	"repository": "thenewdynamic/gohugo-theme-ananke",
+	"repository": "gohugo-ananke/theme",
 	"author": "Bud Parr (https://github.com/budparr)",
 	"maintainers": [
 		{


### PR DESCRIPTION
Ananke is moving into its own GitHub organisation. This adds a note to the README.me with instructions how to update local installations. 
